### PR TITLE
https://github.com/WinMerge/winmerge/pull/1377#issuecomment-1164375545

### DIFF
--- a/Src/DirDoc.cpp
+++ b/Src/DirDoc.cpp
@@ -159,14 +159,8 @@ void CDirDoc::InitCompare(const PathContext & paths, bool bRecursive, CTempPathC
 	if (m_pCompareStats == nullptr)
 		m_pCompareStats.reset(new CompareStats(m_nDirs));
 
-	/** @todo This is needed in order to have the diffContext on the Merge (theApp) class when saving project files
-		but could definatly be done better
-	**/
 	m_pCtxt.reset(new CDiffContext(paths,
 			GetOptionsMgr()->GetInt(OPT_CMP_METHOD)));
-	theApp.diffContext.reset(m_pCtxt.get());
-	/****/
-
 	m_pCtxt->m_bRecursive = bRecursive;
 
 	if (pTempPathContext != nullptr)

--- a/Src/DirDoc.h
+++ b/Src/DirDoc.h
@@ -77,6 +77,8 @@ public:
 	void SetReadOnly(int nIndex, bool bReadOnly);
 	String GetReportFile() const { return m_sReportFile; }
 	void SetReportFile(const String& sReportFile) { m_sReportFile = sReportFile; }
+	const std::vector<String>& GetHiddenItems() const { return m_pCtxt->m_vCurrentlyHiddenItems; }
+	void SetHiddenItems(const std::vector<String>& hiddenItems) { m_pCtxt->m_vCurrentlyHiddenItems = hiddenItems; }
 	bool GetGeneratingReport() const { return m_bGeneratingReport; }
 	void SetGeneratingReport(bool bGeneratingReport) { m_bGeneratingReport = bGeneratingReport; }
 	void SetReport(DirCmpReport* pReport) { m_pReport.reset(pReport);  }

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -2540,14 +2540,8 @@ LRESULT CDirView::OnUpdateUIMessage(WPARAM wParam, LPARAM lParam)
 			else
 				Redisplay();
 		}
-		//@todo mgg - pass the value from the .winmerge here
-		std::vector<String> testHiddenItems;
-		testHiddenItems.push_back(L"create-parking");
-		testHiddenItems.push_back(L"parking-free-capacity");
-		testHiddenItems.push_back(L"app.module.ts.bak");
 
-		//HideItems(GetDiffContext().m_vCurrentlyHiddenItems);
-		HideItems(testHiddenItems);
+		HideItems(GetDiffContext().m_vCurrentlyHiddenItems);
 	}
 
 	return 0; // return value unused
@@ -3293,7 +3287,7 @@ void CDirView::OnHideFilenames()
 /**
  * @brief determine if an item-relative-path is contained in the list of items to hide
  */
-bool CDirView::IsItemToHide(String currentItem, std::vector<String> ItemsToHide)
+bool CDirView::IsItemToHide(const String& currentItem, const std::vector<String>& ItemsToHide) const
 {
 	return std::find(ItemsToHide.begin(), ItemsToHide.end(), currentItem) != ItemsToHide.end();
 }
@@ -3302,7 +3296,7 @@ bool CDirView::IsItemToHide(String currentItem, std::vector<String> ItemsToHide)
  * @brief hides items specified in the .winmerge file
  */
 
-void CDirView::HideItems(std::vector<String> ItemsToHide)
+void CDirView::HideItems(const std::vector<String>& ItemsToHide)
 {
 	CDiffContext& ctxt = GetDiffContext();
 	DirItemIterator it;
@@ -3323,14 +3317,12 @@ void CDirView::HideItems(std::vector<String> ItemsToHide)
 		{
 			SetItemViewFlag(di, ViewCustomFlags::HIDDEN, ViewCustomFlags::VISIBILITY);
 			DeleteItem(it.m_sel);
-			ctxt.m_vCurrentlyHiddenItems.push_back(item_path);
 			num_hidden++;
 		}
 		++it;
 	}
 	m_pList->SetRedraw(TRUE);	// Turn updating back on
 }
-
 
 /**
  * @brief update menu item

--- a/Src/DirView.h
+++ b/Src/DirView.h
@@ -390,8 +390,8 @@ protected:
 	DECLARE_MESSAGE_MAP()
 	bool OnHeaderBeginDrag(LPNMHEADER hdr, LRESULT* pResult);
 	bool OnHeaderEndDrag(LPNMHEADER hdr, LRESULT* pResult);
-	void HideItems(std::vector<String> ItemsToHide);
-	bool IsItemToHide(String currentItem, std::vector<String> ItemsToHide);
+	void HideItems(const std::vector<String>& ItemsToHide);
+	bool IsItemToHide(const String& currentItem, const std::vector<String>& ItemsToHide) const;
 
 private:
 	void Open(CDirDoc *pDoc, const PathContext& paths, DWORD dwFlags[3], FileTextEncoding encoding[3], PackingInfo * infoUnpacker = nullptr);

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -1379,6 +1379,9 @@ bool CMainFrame::DoFileOrFolderOpen(const PathContext * pFiles /*= nullptr*/,
 			// exception. There is no point in checking return value.
 			pDirDoc->InitCompare(tFiles, bRecurse, pTempPathContext);
 
+			const auto* pOpenFolderParams = dynamic_cast<const OpenFolderParams*>(pOpenParams);
+			if (pOpenFolderParams)
+				pDirDoc->SetHiddenItems(pOpenFolderParams->m_hiddenItems);
 			pDirDoc->SetReportFile(sReportFile);
 			pDirDoc->SetDescriptions(strDesc);
 			pDirDoc->SetTitle(nullptr);
@@ -2349,6 +2352,7 @@ void CMainFrame::OnSaveProject()
 			}
 			pOpenDoc->m_bRecurse = ctxt.m_bRecursive;
 			pOpenDoc->m_strExt = static_cast<FileFilterHelper*>(ctxt.m_piFilterGlobal)->GetFilterNameOrMask();
+			pOpenDoc->m_hiddenItems = ctxt.m_vCurrentlyHiddenItems;
 		}
 	}
 

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -113,6 +113,12 @@ public:
 		virtual ~OpenAutoFileParams() {}
 	};
 
+	struct OpenFolderParams : public OpenFileParams
+	{
+		virtual ~OpenFolderParams() {}
+		std::vector<String> m_hiddenItems;
+	};
+
 	CMainFrame();
 
 // Attributes

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -1231,7 +1231,7 @@ bool CMergeApp::SaveProjectFile(const String& sProject, const ProjectFile &proje
 {
 	try
 	{
-		project.Save(sProject, *diffContext.get());
+		project.Save(sProject);
 	}
 	catch (Poco::Exception& e)
 	{
@@ -1337,8 +1337,15 @@ bool CMergeApp::LoadAndOpenProjectFile(const String& sProject, const String& sRe
 				GetOptionsMgr()->Set(OPT_CMP_METHOD, projItem.GetCompareMethod());
 		}
 
+		std::unique_ptr<CMainFrame::OpenFolderParams> pOpenFolderParams;
+		if (projItem.HasHiddenItems())
+		{
+			pOpenFolderParams = std::make_unique<CMainFrame::OpenFolderParams>();
+			pOpenFolderParams->m_hiddenItems = projItem.GetHiddenItems();
+		}
+
 		rtn &= GetMainFrame()->DoFileOrFolderOpen(&tFiles, dwFlags, nullptr, sReportFile, bRecursive,
-			nullptr, pInfoUnpacker.get(), pInfoPrediffer.get());
+			nullptr, pInfoUnpacker.get(), pInfoPrediffer.get(), 0, pOpenFolderParams.get());
 	}
 
 	AddToRecentProjectsMRU(sProject.c_str());

--- a/Src/Merge.h
+++ b/Src/Merge.h
@@ -24,7 +24,6 @@
 #include <memory>
 #include "MergeCmdLineInfo.h"
 #include "resource.h"       // main symbols
-#include "DiffContext.h"
 
 struct FileFilter;
 class FileFilterHelper;
@@ -68,7 +67,6 @@ public:
 	MergeCmdLineInfo::ExitNoDiff m_bExitIfNoDiff; /**< Exit if files are identical? */
 	std::unique_ptr<LineFiltersList> m_pLineFilters; /**< List of linefilters */
 	std::unique_ptr<SubstitutionFiltersList> m_pSubstitutionFiltersList;
-	std::unique_ptr<CDiffContext> diffContext ; /* diffContext to keep/restore list of hidden items */
 
 	WORD GetLangId() const;
 	String GetLangName() const;

--- a/Src/OpenDoc.h
+++ b/Src/OpenDoc.h
@@ -23,6 +23,7 @@ public:
 	bool	m_bRecurse;
 	String	m_strExt;
 	String	m_strUnpackerPipeline;
+	std::vector<String> m_hiddenItems;
 
 protected:
 	virtual BOOL OnNewDocument();

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -926,6 +926,7 @@ void COpenView::OnSaveProject()
 		projItem.SetFilterCommentsLines(m_bFilterCommentsLines);
 		projItem.SetCompareMethod(m_nCompareMethod);
 	}
+	projItem.SetHiddenItems(GetDocument()->m_hiddenItems);
 
 	project.Items().push_back(projItem);
 

--- a/Src/ProjectFile.cpp
+++ b/Src/ProjectFile.cpp
@@ -68,10 +68,10 @@ void writeElement(XMLWriter& writer, const std::string& tagname, const std::stri
 	writer.endElement("", "", tagname);
 }
 
-void saveHiddenItems(XMLWriter& writer, const CDiffContext& diffContext) 
+void saveHiddenItems(XMLWriter& writer, const std::vector<String>& hiddenItems) 
 {
 	writer.startElement("", "", Hidden_list_element_name);
-	for (String hiddenItem : diffContext.m_vCurrentlyHiddenItems) {
+	for (const auto& hiddenItem : hiddenItems) {
 		writeElement(writer, Hidden_items_element_name, toUTF8(hiddenItem));
 	}
 	writer.endElement("", "", Hidden_list_element_name);
@@ -198,7 +198,7 @@ public:
 		//This nodes are under Hidden_list_element_name
 		else if (nodename ==  Hidden_items_element_name)
 		{
-			currentItem.m_vSavedHiddenItems.push_back(token);
+			currentItem.m_vSavedHiddenItems.push_back(toTString(token));
 			currentItem.m_bHasHiddenItems = true;
 		}
 	}
@@ -369,7 +369,7 @@ bool ProjectFile::Read(const String& path)
  * @param [out] sError Error string if error happened.
  * @return true if saving succeeded, false if error happened.
  */
-bool ProjectFile::Save(const String& path, const CDiffContext& diffContext) const
+bool ProjectFile::Save(const String& path) const
 {
 	FileStream out(toUTF8(path), FileStream::trunc);
 	XMLWriter writer(out, XMLWriter::WRITE_XML_DECLARATION | XMLWriter::PRETTY_PRINT);
@@ -414,8 +414,8 @@ bool ProjectFile::Save(const String& path, const CDiffContext& diffContext) cons
 					writeElement(writer, Ignore_comment_diff_element_name, item.m_bFilterCommentsLines ? "1" : "0");
 				if (item.m_bSaveCompareMethod)
 					writeElement(writer, Compare_method_element_name, std::to_string(item.m_nCompareMethod));
-				if (diffContext.m_vCurrentlyHiddenItems.size() > 0) 
-					saveHiddenItems(writer, diffContext);
+				if (item.m_vSavedHiddenItems.size() > 0) 
+					saveHiddenItems(writer, item.m_vSavedHiddenItems);
 			}
 			writer.endElement("", "", Paths_element_name);
 		}

--- a/Src/ProjectFile.h
+++ b/Src/ProjectFile.h
@@ -8,7 +8,6 @@
 
 #include "UnicodeString.h"
 #include "PathContext.h"
-#include "DiffContext.h"
 
 class ProjectFileItem
 {
@@ -31,6 +30,7 @@ public:
 	bool HasIgnoreCodepage() const;
 	bool HasFilterCommentsLines() const;
 	bool HasCompareMethod() const;
+	bool HasHiddenItems() const;
 
 	String GetLeft(bool * pReadOnly = nullptr) const;
 	bool GetLeftReadOnly() const;
@@ -50,6 +50,7 @@ public:
 	bool GetIgnoreCodepage() const;
 	bool GetFilterCommentsLines() const;
 	int GetCompareMethod() const;
+	const std::vector<String>& GetHiddenItems() const;
 
 	void SetLeft(const String& sLeft, const bool * pReadOnly = nullptr);
 	void SetMiddle(const String& sMiddle, const bool * pReadOnly = nullptr);
@@ -66,6 +67,7 @@ public:
 	void SetIgnoreCodepage(bool bIgnoreCodepage);
 	void SetFilterCommentsLines(bool bFilterCommentsLines);
 	void SetCompareMethod(int nCompareMethod);
+	void SetHiddenItems(const std::vector<String>& hiddenItems);
 
 	void GetPaths(PathContext& files, bool & bSubFolders) const;
 	void SetPaths(const PathContext& files, bool bSubFolders = false);
@@ -114,8 +116,8 @@ private:
 	bool m_bFilterCommentsLines; /**< The value of the "Ignore comment differences" setting */
 	bool m_bHasCompareMethod; /**< Has "Compare method" setting? */
 	int m_nCompareMethod; /**< The value of the "Compare method" setting */
-	bool m_bHasHiddenItems; /**< Has "Compare method" setting? */
-	std::vector<std::string> m_vSavedHiddenItems; /**< The list of hidden items saved */
+	bool m_bHasHiddenItems; /**< Has "Hidden items" setting? */
+	std::vector<String> m_vSavedHiddenItems; /**< The list of hidden items saved */
 	bool m_bSaveFilter; /**< Save filter? */
 	bool m_bSaveSubfolders; /**< Save subfolders? */
 	bool m_bSaveUnpacker; /**< Save unpacker? */
@@ -140,7 +142,7 @@ class ProjectFile
 {
 public:
 	bool Read(const String& path);
-	bool Save(const String& path, const CDiffContext& diffContext) const;
+	bool Save(const String& path) const;
 	const std::list<ProjectFileItem>& Items() const { return m_items; };
 	std::list<ProjectFileItem>& Items() { return m_items; }
 	static const String PROJECTFILE_EXT;
@@ -280,6 +282,15 @@ inline bool ProjectFileItem::HasFilterCommentsLines() const
 inline bool ProjectFileItem::HasCompareMethod() const
 {
 	return m_bHasCompareMethod;
+}
+
+/** 
+ * @brief Returns if "Hidden items" setting is defined in projectfile.
+ * @return true if project file has "Hidden items" setting definition.
+ */
+inline bool ProjectFileItem::HasHiddenItems() const
+{
+	return m_bHasHiddenItems;
 }
 
 /** 
@@ -522,6 +533,24 @@ inline int ProjectFileItem::GetCompareMethod() const
 inline void ProjectFileItem::SetCompareMethod(int nCompareMethod)
 {
 	m_nCompareMethod = nCompareMethod;
+}
+
+/** 
+ * @brief Returns the value of the "Hidden items" setting.
+ * @return The value of the "Hidden items" setting
+ */
+inline const std::vector<String>& ProjectFileItem::GetHiddenItems() const
+{
+	return m_vSavedHiddenItems;
+}
+
+/** 
+ * @brief Set the value of the "Hidden items" setting.
+ * @param [in] hiddenItems New value of the "Hidden items" setting to set.
+ */
+inline void ProjectFileItem::SetHiddenItems(const std::vector<String>& hiddenItems)
+{
+	m_vSavedHiddenItems = hiddenItems;
 }
 
 /** 


### PR DESCRIPTION
I implemented what I described in https://github.com/WinMerge/winmerge/pull/1377#issuecomment-1164375545.

Since there can be more than one folder comparison window, CMergeApp::diffContext can be overwritten many times, so I changed to save hidden items to a project file without using this variable.